### PR TITLE
[MV-481][BUGFIX] Add missing include to use size_t

### DIFF
--- a/ecf_codec.h
+++ b/ecf_codec.h
@@ -10,6 +10,7 @@
 #ifndef ECF_CODEC_H
 #define ECF_CODEC_H
 
+#include <cstddef>
 #include <cstdint>
 #include <vector>
 #include "ecf_codec_export.h"


### PR DESCRIPTION
Trying to compile on ubuntu-22, Metavision Computational Imaging, there are errors of type:

```
In file included from /home/pdonzier/code/metavision-computational-imaging/sdk/modules/hybrid/cpp/src/io/hybrid_data_writer_hdf5.cpp:9:
/usr/local/include/hdf5_ecf/ecf_codec.h:27:22: error: 'size_t' does not name a type
   27 |     ECF_CODEC_EXPORT size_t operator()(const std::uint8_t *cur_raw_data, const std::uint8_t *raw_data_end,
      |                      ^~~~~~
/usr/local/include/hdf5_ecf/ecf_codec.h:16:1: note: 'size_t' is defined in header '<cstddef>'; did you forget to '#include <cstddef>'?
   15 | #include "ecf_codec_export.h"
  +++ |+#include <cstddef>
```